### PR TITLE
Added support for multiline formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ npm link
 cchistory                    # Current project history
 cchistory --global           # All projects
 cchistory --list-projects    # See all available projects
+cchistory --multiline        # Split multi-command shells onto separate lines
 cchistory | grep docker      # Find Docker commands  
 cchistory | tail -5          # Last 5 commands
 cchistory my-app | tail -10  # Last 10 from specific project
@@ -123,6 +124,8 @@ Extracts commands from:
 cchistory [project-name]    # Show history for specific project (by name or path)
 cchistory --global          # Show history from all projects  
 cchistory --list-projects   # List all available Claude projects
+cchistory -m, --multiline   # Split multi-command shells onto separate lines
+cchistory --include-failed  # Include failed command executions
 cchistory --help            # Show usage info
 ```
 
@@ -137,7 +140,17 @@ Each line shows:
 - **project-name**: Which Claude project ran the command
 - **command**: The actual shell command
 
-Multi-line commands use zsh history format with `\\n` for newlines.
+When Claude runs several commands in one shell, they are shown on a single line in zsh history format with `\n` separating them.
+
+Use `-m` / `--multiline` to break them onto separate lines instead. Each line keeps the parent's history index with a `.N` sub-index so it's clear they ran in the same shell:
+
+```
+1610.1  cd /Users/you/projects/foobar
+1610.2  git add README.md
+1610.3  git commit -m "yolo"
+```
+
+> Note: splitting happens on the `\n` separator, so a command whose own text literally contains `\n` (e.g. `printf 'a\nb'`) will also be broken at that point.
 
 ## Unix Philosophy
 

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -27,7 +27,7 @@ type MockedProjectDiscovery = {
 
 type MockedOutputFormatter = {
   formatProjectList: ReturnType<typeof vi.fn>;
-  formatCommandLine: ReturnType<typeof vi.fn>;
+  formatCommandLines: ReturnType<typeof vi.fn>;
   writeLineWithSigpipeCheck: ReturnType<typeof vi.fn>;
 };
 
@@ -239,10 +239,10 @@ describe('CLI Functions', () => {
       })();
 
       const mockFormatter = {
-        formatCommandLine: vi
+        formatCommandLines: vi
           .fn()
-          .mockReturnValueOnce('   1  npm install')
-          .mockReturnValueOnce('   2  npm test'),
+          .mockReturnValueOnce(['   1  npm install'])
+          .mockReturnValueOnce(['   2  npm test']),
         writeLineWithSigpipeCheck: vi.fn().mockReturnValue(true),
       };
 
@@ -255,17 +255,19 @@ describe('CLI Functions', () => {
 
       await processCommandStream(mockStream, options, isGlobal);
 
-      expect(mockFormatter.formatCommandLine).toHaveBeenCalledTimes(2);
-      expect(mockFormatter.formatCommandLine).toHaveBeenNthCalledWith(
+      expect(mockFormatter.formatCommandLines).toHaveBeenCalledTimes(2);
+      expect(mockFormatter.formatCommandLines).toHaveBeenNthCalledWith(
         1,
         mockCommands[0],
         1,
+        false,
         false
       );
-      expect(mockFormatter.formatCommandLine).toHaveBeenNthCalledWith(
+      expect(mockFormatter.formatCommandLines).toHaveBeenNthCalledWith(
         2,
         mockCommands[1],
         2,
+        false,
         false
       );
       expect(mockFormatter.writeLineWithSigpipeCheck).toHaveBeenCalledTimes(2);
@@ -294,7 +296,7 @@ describe('CLI Functions', () => {
       })();
 
       const mockFormatter = {
-        formatCommandLine: vi.fn().mockReturnValue('   1  npm install'),
+        formatCommandLines: vi.fn().mockReturnValue(['   1  npm install']),
         writeLineWithSigpipeCheck: vi.fn().mockReturnValue(true),
       };
 
@@ -307,10 +309,11 @@ describe('CLI Functions', () => {
 
       await processCommandStream(mockStream, options, isGlobal);
 
-      expect(mockFormatter.formatCommandLine).toHaveBeenCalledTimes(1);
-      expect(mockFormatter.formatCommandLine).toHaveBeenCalledWith(
+      expect(mockFormatter.formatCommandLines).toHaveBeenCalledTimes(1);
+      expect(mockFormatter.formatCommandLines).toHaveBeenCalledWith(
         mockCommands[0],
         1,
+        false,
         false
       );
     });
@@ -336,7 +339,7 @@ describe('CLI Functions', () => {
       })();
 
       const mockFormatter = {
-        formatCommandLine: vi.fn().mockReturnValue('   1  npm install'),
+        formatCommandLines: vi.fn().mockReturnValue(['   1  npm install']),
         writeLineWithSigpipeCheck: vi.fn().mockReturnValue(false), // SIGPIPE detected
       };
 
@@ -351,7 +354,7 @@ describe('CLI Functions', () => {
         processCommandStream(mockStream, options, isGlobal)
       ).rejects.toThrow('process.exit');
 
-      expect(mockFormatter.formatCommandLine).toHaveBeenCalledTimes(1);
+      expect(mockFormatter.formatCommandLines).toHaveBeenCalledTimes(1);
       expect(mockFormatter.writeLineWithSigpipeCheck).toHaveBeenCalledTimes(1);
     });
 
@@ -361,7 +364,7 @@ describe('CLI Functions', () => {
       })();
 
       const mockFormatter = {
-        formatCommandLine: vi.fn(),
+        formatCommandLines: vi.fn(),
         writeLineWithSigpipeCheck: vi.fn(),
       };
 

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -118,6 +118,7 @@ describe('Integration Tests', () => {
       expect(result.stdout).toContain('--global');
       expect(result.stdout).toContain('--list-projects');
       expect(result.stdout).toContain('--include-failed');
+      expect(result.stdout).toContain('--multiline');
     });
 
     it('should show version when run with --version', async () => {
@@ -200,6 +201,45 @@ describe('Integration Tests', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('git status');
       expect(result.stdout).toContain('[project1');
+    });
+
+    it('should split multi-command shells with --multiline', async () => {
+      const multilineCommand = {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              name: 'Bash',
+              input: {
+                command:
+                  'cd /Users/test/project1\ngit add README.md\ngit commit -m "yolo"',
+              },
+            },
+          ],
+        },
+        timestamp: '2025-06-07T12:00:00.000Z',
+        cwd: '/Users/test/project1',
+      };
+
+      await createTestProject('-Users-test-project1', '/Users/test/project1', [
+        { filename: 'session1.jsonl', commands: [multilineCommand] },
+      ]);
+
+      const result = await runCLI(['--global', '--multiline']);
+
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.trim().split('\n');
+      expect(lines).toHaveLength(3);
+      expect(lines[0]).toContain('1.1');
+      expect(lines[0]).toContain('cd /Users/test/project1');
+      expect(lines[1]).toContain('1.2');
+      expect(lines[1]).toContain('git add README.md');
+      expect(lines[2]).toContain('1.3');
+      expect(lines[2]).toContain('git commit -m "yolo"');
+      // Each split line keeps the project prefix
+      expect(lines.every((line) => line.includes('[project1'))).toBe(true);
     });
 
     it('should merge multiple projects chronologically', async () => {

--- a/src/__tests__/output-formatter.test.ts
+++ b/src/__tests__/output-formatter.test.ts
@@ -102,6 +102,61 @@ describe('OutputFormatter', () => {
     });
   });
 
+  describe('formatCommandLines', () => {
+    it('returns a single unchanged line when multiline is disabled', () => {
+      const command: ClaudeCommand = {
+        timestamp: new Date('2025-06-07T12:00:00.000Z'),
+        command: 'cd /tmp\\ngit status',
+        source: 'bash',
+      };
+
+      const result = formatter.formatCommandLines(command, 5, false, false);
+      expect(result).toEqual(['   5  cd /tmp\\ngit status']);
+    });
+
+    it('suffixes a single-command shell with .1 when multiline is enabled', () => {
+      const command: ClaudeCommand = {
+        timestamp: new Date('2025-06-07T12:00:00.000Z'),
+        command: 'npm install commander',
+        source: 'bash',
+      };
+
+      const result = formatter.formatCommandLines(command, 1, false, true);
+      expect(result).toEqual(['   1.1  npm install commander']);
+    });
+
+    it('splits a multi-command shell into sub-indexed lines', () => {
+      const command: ClaudeCommand = {
+        timestamp: new Date('2025-06-07T12:00:00.000Z'),
+        command:
+          'cd /Users/test/foobar\\ngit add README.md\\ngit commit -m "yolo"',
+        source: 'bash',
+      };
+
+      const result = formatter.formatCommandLines(command, 1610, false, true);
+      expect(result).toEqual([
+        '1610.1  cd /Users/test/foobar',
+        '1610.2  git add README.md',
+        '1610.3  git commit -m "yolo"',
+      ]);
+    });
+
+    it('repeats the project prefix on each line in global mode', () => {
+      const command: ClaudeCommand = {
+        timestamp: new Date('2025-06-07T12:00:00.000Z'),
+        command: 'cd app\\nnpm test',
+        source: 'bash',
+        projectPath: '/Users/test/foobar',
+      };
+
+      const result = formatter.formatCommandLines(command, 7, true, true);
+      expect(result).toEqual([
+        '   7.1  [foobar         ] cd app',
+        '   7.2  [foobar         ] npm test',
+      ]);
+    });
+  });
+
   describe('formatProjectList', () => {
     it('should format empty project list', () => {
       const projects: ProjectInfo[] = [];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,10 +90,22 @@ export async function processCommandStream(
       continue;
     }
 
-    const line = formatter.formatCommandLine(command, index, isGlobal);
-    const shouldContinue = formatter.writeLineWithSigpipeCheck(line);
+    const lines = formatter.formatCommandLines(
+      command,
+      index,
+      isGlobal,
+      options.multiline ?? false
+    );
 
-    if (!shouldContinue) {
+    let stopped = false;
+    for (const line of lines) {
+      if (!formatter.writeLineWithSigpipeCheck(line)) {
+        stopped = true;
+        break;
+      }
+    }
+
+    if (stopped) {
       break;
     }
 
@@ -137,6 +149,10 @@ program
   .option(
     '--include-failed',
     'include failed command executions (default: only successful)'
+  )
+  .option(
+    '-m, --multiline',
+    'split multi-line commands onto separate lines with sub-indices (e.g. 1610.1)'
   )
   .action(async (project: string | undefined, options: CLIOptions) => {
     await main(project, options);

--- a/src/output-formatter.ts
+++ b/src/output-formatter.ts
@@ -19,16 +19,59 @@ export class OutputFormatter {
     index: number,
     isGlobal: boolean
   ): string {
-    const indexStr = index.toString().padStart(4);
+    return this.buildLine(
+      index.toString().padStart(4),
+      command,
+      isGlobal,
+      command.command
+    );
+  }
 
+  /**
+   * Format a command into one or more output lines.
+   *
+   * When `multiline` is enabled, multi-command shells (joined by the parser with
+   * a literal `\n` marker) are split into one line per command, each sharing the
+   * parent history index with a `.N` sub-index (e.g. 1610.1, 1610.2). Single
+   * commands still get a `.1` suffix so the numbering is uniform. When disabled,
+   * a single line is returned with the commands kept on one line (default).
+   */
+  formatCommandLines(
+    command: ClaudeCommand,
+    index: number,
+    isGlobal: boolean,
+    multiline: boolean
+  ): string[] {
+    if (!multiline) {
+      return [this.formatCommandLine(command, index, isGlobal)];
+    }
+
+    const baseLabel = index.toString().padStart(4);
+    // The parser joins multi-line commands with a literal `\n` marker.
+    const parts = command.command.split('\\n');
+    return parts.map((part, i) =>
+      this.buildLine(`${baseLabel}.${i + 1}`, command, isGlobal, part)
+    );
+  }
+
+  /**
+   * Build a single output line from a pre-rendered index label and command text,
+   * adding the `[project]` prefix when rendering global (cross-project) output.
+   */
+  private buildLine(
+    label: string,
+    command: ClaudeCommand,
+    isGlobal: boolean,
+    text: string
+  ): string {
     if (isGlobal && command.projectPath) {
       // Extract project name from path for global view
       const projectName = this.extractProjectName(command.projectPath);
       const projectPrefix = `[${projectName.padEnd(15)}] `;
-      return `${indexStr}  ${projectPrefix}${command.command}`;
+      return `${label}  ${projectPrefix}${text}`;
     }
 
-    return `${indexStr}  ${command.command}`;
+    return `${label}  ${text}`;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,4 +54,5 @@ export interface CLIOptions {
   global?: boolean;
   listProjects?: boolean;
   includeFailed?: boolean;
+  multiline?: boolean;
 }


### PR DESCRIPTION
# Add `-m` / `--multiline` flag to split multi-command shells onto separate lines

## Summary

When Claude runs several shell commands in a single `Bash` tool call, the parser
joins them with a literal `\n` marker, so they render as one long, hard-to-read
line:

```
1610  [foobar] cd /Users/you/foobar\ngit add README.md\ngit commit -m "yolo"
```

This PR adds an opt-in `-m` / `--multiline` flag that breaks those into one
output line per command, sharing the parent history index with a `.N` sub-index
so it's clear they came from the same shell invocation:

```
1610.1  [foobar] cd /Users/you/foobar
1610.2  [foobar] git add README.md
1610.3  [foobar] git commit -m "yolo"
```

In multiline mode every printed line is suffixed — single-command shells get
`.1` — so the numbering stays uniform. The parent index still increments once
per command. Default output is unchanged.

## How it works

Splitting happens entirely in the formatting layer. The parser already collapses
real newlines into the literal two-character `\n` marker, so the formatter splits
the stored `command` string on that marker. No change to the parser or data
model.

- `formatCommandLine` is refactored to delegate to a new private `buildLine`
  helper (which renders the index label, the `[project]` prefix in global mode,
  and the command text). Its signature and output are unchanged.
- A new `formatCommandLines(command, index, isGlobal, multiline)` returns the
  array of lines: one unchanged line when `multiline` is off, or one sub-indexed
  line per command when it's on (repeating the project prefix on each line).
- `processCommandStream` writes the array of lines and breaks cleanly on a closed
  pipe (`head`/`tail`).

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add `multiline?: boolean` to `CLIOptions` |
| `src/output-formatter.ts` | Extract `buildLine` helper; add `formatCommandLines` |
| `src/cli.ts` | Register `-m, --multiline`; write per-command line arrays with pipe-safe handling |
| `src/__tests__/output-formatter.test.ts` | 4 new `formatCommandLines` tests |
| `src/__tests__/cli.test.ts` | Update 3 tests to the new `formatCommandLines` call |
| `src/__tests__/integration.test.ts` | New end-to-end `--multiline` test + `--help` assertion |
| `README.md` | Document the flag in Usage/Options and Output Format |

## Known limitation

Splitting is done on the `\n` separator, so a command whose own text literally
contains `\n` (e.g. `printf 'a\nb'`) is also broken at that point. This is a
pre-existing representational ambiguity — the joined form can't distinguish a
real newline from a literal `\n` — and is documented in the README.

## Testing

- `npm run check` (Biome) — clean
- `npm run typecheck` — clean
- `npm run test:ci` — **91 passed** (up from 86)
- Manual smoke test against real history: default output unchanged; `--multiline`
  splits correctly with per-line project prefixes; piping (`-m | tail`) works
  with exit code 0.
