### PR TITLE
Add tail -f style --follow mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,34 @@ cchistory                    # Current project history
 cchistory --global           # All projects
 cchistory --list-projects    # See all available projects
 cchistory --multiline        # Split multi-command shells onto separate lines
-cchistory | grep docker      # Find Docker commands  
+cchistory --follow           # Stream new commands live (like tail -f)
+cchistory | grep docker      # Find Docker commands
 cchistory | tail -5          # Last 5 commands
 cchistory my-app | tail -10  # Last 10 from specific project
 cchistory ~/code/my-app      # Project by full path
 ```
 
+### Follow mode
+
+`-f` / `--follow` works like `tail -f`: cchistory prints the existing history and
+then stays open, printing new commands as Claude Code writes them. It keeps
+following across newly started sessions, and combines with the other flags and
+with pipes:
+
+```bash
+cchistory -f                 # Follow the current project
+cchistory -f --global        # Follow every project at once
+cchistory -f | grep git      # Watch for git commands as they happen
+```
+
+Press `Ctrl-C` to stop. While following, the live commands are printed in the
+order they arrive (matching `tail -f file1 file2`), rather than re-sorted by
+timestamp.
+
 ## ✨ Features
 
 - 🔍 Extract all Bash commands Claude executed across projects
-- 🗂️ Filter by specific project or search globally  
+- 🗂️ Filter by specific project or search globally
 - 📊 Standard Unix tool compatibility (`grep`, `awk`, `sort`)
 - ⚡ Fast streaming parser for large conversation logs
 - 🚀 Zero-config - works with existing Claude Code setup
@@ -72,7 +90,7 @@ cchistory ~/code/my-app      # Project by full path
 Claude Code stores conversation history in `~/.claude/projects/`. This tool:
 
 1. Finds your Claude projects
-2. Streams through conversation logs  
+2. Streams through conversation logs
 3. Extracts shell commands Claude executed
 4. Formats them like traditional shell history
 
@@ -113,7 +131,7 @@ Extracts commands from:
 
 ## Requirements
 
-- Node.js 20+ 
+- Node.js 20+
 - Claude Code with conversation history in `~/.claude/projects/`
 
 **Note**: Claude Code automatically cleans up conversation transcripts based on the `cleanupPeriodDays` setting (default: 30 days). Commands older than this period won't appear in cchistory output. You can adjust this retention period in [Claude Code's settings](https://docs.anthropic.com/en/docs/claude-code/settings) if needed.
@@ -122,9 +140,10 @@ Extracts commands from:
 
 ```
 cchistory [project-name]    # Show history for specific project (by name or path)
-cchistory --global          # Show history from all projects  
+cchistory --global          # Show history from all projects
 cchistory --list-projects   # List all available Claude projects
 cchistory -m, --multiline   # Split multi-command shells onto separate lines
+cchistory -f, --follow      # Keep running and print new commands as they happen
 cchistory --include-failed  # Include failed command executions
 cchistory --help            # Show usage info
 ```
@@ -157,7 +176,7 @@ Use `-m` / `--multiline` to break them onto separate lines instead. Each line ke
 `cchistory` does one thing well: extract shell commands. Use it with standard Unix tools:
 
 - `grep` for filtering
-- `head`/`tail` for limiting output  
+- `head`/`tail` for limiting output
 - `awk` for field processing
 - `sort`/`uniq` for analysis
 - Pipe to files for documentation

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -318,6 +318,54 @@ describe('CLI Functions', () => {
       );
     });
 
+    it('keeps unknown-outcome commands visible while filtering only confirmed failures', async () => {
+      // Orphaned commands flush with success undefined (outcome unknown). The
+      // default filter drops only confirmed failures (success === false), so an
+      // unknown-outcome command must still appear.
+      const mockCommands: ClaudeCommand[] = [
+        {
+          timestamp: new Date('2025-06-07T12:00:00.000Z'),
+          command: 'npm run dev', // orphan: never completed -> unknown
+          source: 'bash',
+          success: undefined,
+        },
+        {
+          timestamp: new Date('2025-06-07T12:01:00.000Z'),
+          command: 'false', // confirmed failure -> filtered
+          source: 'bash',
+          success: false,
+        },
+      ];
+
+      const mockStream = (async function* () {
+        for (const command of mockCommands) {
+          yield command;
+        }
+      })();
+
+      const mockFormatter = {
+        formatCommandLines: vi.fn().mockReturnValue(['   1  npm run dev']),
+        writeLineWithSigpipeCheck: vi.fn().mockReturnValue(true),
+      };
+
+      vi.mocked(OutputFormatter).mockImplementation(
+        () => mockFormatter as MockedOutputFormatter
+      );
+
+      const options: CLIOptions = { includeFailed: false };
+
+      await processCommandStream(mockStream, options, false);
+
+      // Only the unknown-outcome command is rendered; the failure is dropped.
+      expect(mockFormatter.formatCommandLines).toHaveBeenCalledTimes(1);
+      expect(mockFormatter.formatCommandLines).toHaveBeenCalledWith(
+        mockCommands[0],
+        1,
+        false,
+        false
+      );
+    });
+
     it('should stop processing when SIGPIPE is detected', async () => {
       const mockCommands: ClaudeCommand[] = [
         {

--- a/src/__tests__/command-success.test.ts
+++ b/src/__tests__/command-success.test.ts
@@ -164,7 +164,7 @@ describe('Command Success Tracking', () => {
       commands.push(command);
     }
 
-    // Flush pending commands (this should yield the orphaned command with success=true)
+    // Flush pending commands (orphaned command surfaces with unknown outcome)
     const pendingGenerator = (
       parser as unknown as {
         flushPendingCommands: () => Generator<ClaudeCommand>;
@@ -177,7 +177,7 @@ describe('Command Success Tracking', () => {
     expect(commands).toHaveLength(1);
     const command = commands[0];
     expect(command.command).toBe('ls -la');
-    expect(command.success).toBe(true); // Should default to true for orphaned commands
+    expect(command.success).toBeUndefined(); // outcome unknown, not assumed success
   });
 
   it('should match tool uses with results by ID even when not sequential', async () => {

--- a/src/__tests__/follow-tailer.test.ts
+++ b/src/__tests__/follow-tailer.test.ts
@@ -342,6 +342,103 @@ describe('createFollowStream', () => {
     ]);
   });
 
+  it('flushes a settled file orphan during catch-up even when it is the newest file (no live session)', async () => {
+    // Claude is not running: every file is old, including the most recently
+    // modified one. Liveness is judged by mtime age, not file rank, so the
+    // newest file is still treated as a closed session and its orphan surfaces
+    // during catch-up — not left stranded waiting for a result that never comes.
+    const file = join(testDir, 's1.jsonl');
+    await writeFile(file, `${bashLine('echo stale', { id: 'tool-stale' })}\n`);
+    const { utimes } = await import('node:fs/promises');
+    await utimes(
+      file,
+      new Date('2025-06-07T11:00:00Z'),
+      new Date('2025-06-07T11:00:00Z')
+    );
+
+    const gen = createFollowStream([testDir], {
+      pollMs: 20,
+      idleFlushMs: 0, // idle flush disabled — catch-up is the only path
+      signal: controller.signal,
+    });
+    const { commands, done } = background(gen);
+
+    await waitFor(() => commands.length >= 1, 1000);
+    controller.abort();
+    await done;
+
+    expect(commands.map((c) => c.command)).toEqual(['echo stale']);
+  });
+
+  it('does not flush a concurrent live session orphan during catch-up', async () => {
+    // Two sessions run concurrently -> two recently-written files. The older
+    // (but still live) one holds an in-flight command. A "newest file is the
+    // only live one" rule would flush it prematurely as a success; mtime-age
+    // liveness defers it so the real tool_result decides its status.
+    const liveA = join(testDir, 'a.jsonl'); // in-flight command
+    const liveB = join(testDir, 'b.jsonl'); // more recently active
+    await writeFile(liveA, `${bashLine('echo running', { id: 'tool-run' })}\n`);
+    await writeFile(liveB, `${bashLine('echo other')}\n`); // no id -> immediate
+
+    const gen = createFollowStream([testDir], {
+      pollMs: 20,
+      idleFlushMs: 10_000, // long window: live loop won't idle-flush in-test
+      signal: controller.signal,
+    });
+    const { commands, done } = background(gen);
+
+    // The complete command appears; the in-flight one must stay held.
+    await waitFor(() => commands.length >= 1);
+    await sleep(100);
+    expect(commands.map((c) => c.command)).toEqual(['echo other']);
+
+    // The real result arrives (an error) and matches the held command.
+    await appendFile(liveA, `${resultLine('tool-run', true)}\n`);
+    await waitFor(() => commands.length >= 2);
+    controller.abort();
+    await done;
+
+    const running = commands.find((c) => c.command === 'echo running');
+    expect(running).toBeDefined();
+    expect(running?.success).toBe(false); // matched the real result, not flushed
+  });
+
+  it('does not emit a command twice when its result arrives after the idle flush', async () => {
+    // A command that runs longer than idleFlushMs: its tool_use is followed by a
+    // quiet gap, so the idle flush surfaces it as an assumed success. When the
+    // real tool_result finally lands (here: an error), it must NOT produce a
+    // second copy, nor retroactively rewrite the already-emitted status — the
+    // pending entry was cleared by the flush, so the late result is a no-op.
+    const file = join(testDir, 's1.jsonl');
+    await writeFile(file, `${bashLine('echo slow', { id: 'tool-slow' })}\n`);
+
+    const gen = createFollowStream([testDir], {
+      pollMs: 20,
+      idleFlushMs: 60, // shorter than the command's run time
+      signal: controller.signal,
+    });
+    const { commands, done } = background(gen);
+
+    // Idle flush fires after the quiet window and surfaces the orphan once.
+    await waitFor(() => commands.length >= 1);
+    expect(commands.map((c) => c.command)).toEqual(['echo slow']);
+    expect(commands[0].success).toBe(true); // assumed success
+
+    // The command finishes much later and its real result (an error) arrives.
+    await appendFile(file, `${resultLine('tool-slow', true)}\n`);
+    // Give the live loop several poll cycles to drain the appended result.
+    await sleep(150);
+
+    controller.abort();
+    await done;
+
+    // Still exactly one occurrence, still the flushed status — no duplicate and
+    // no retroactive correction from the late result.
+    expect(commands).toHaveLength(1);
+    expect(commands[0].command).toBe('echo slow');
+    expect(commands[0].success).toBe(true);
+  });
+
   it('stops promptly when the signal is aborted', async () => {
     await writeFile(join(testDir, 's1.jsonl'), `${bashLine('echo only')}\n`);
     const gen = createFollowStream([testDir], {

--- a/src/__tests__/follow-tailer.test.ts
+++ b/src/__tests__/follow-tailer.test.ts
@@ -405,7 +405,7 @@ describe('createFollowStream', () => {
 
   it('does not emit a command twice when its result arrives after the idle flush', async () => {
     // A command that runs longer than idleFlushMs: its tool_use is followed by a
-    // quiet gap, so the idle flush surfaces it as an assumed success. When the
+    // quiet gap, so the idle flush surfaces it with an unknown outcome. When the
     // real tool_result finally lands (here: an error), it must NOT produce a
     // second copy, nor retroactively rewrite the already-emitted status — the
     // pending entry was cleared by the flush, so the late result is a no-op.
@@ -422,7 +422,7 @@ describe('createFollowStream', () => {
     // Idle flush fires after the quiet window and surfaces the orphan once.
     await waitFor(() => commands.length >= 1);
     expect(commands.map((c) => c.command)).toEqual(['echo slow']);
-    expect(commands[0].success).toBe(true); // assumed success
+    expect(commands[0].success).toBeUndefined(); // unknown, not assumed success
 
     // The command finishes much later and its real result (an error) arrives.
     await appendFile(file, `${resultLine('tool-slow', true)}\n`);
@@ -436,7 +436,7 @@ describe('createFollowStream', () => {
     // no retroactive correction from the late result.
     expect(commands).toHaveLength(1);
     expect(commands[0].command).toBe('echo slow');
-    expect(commands[0].success).toBe(true);
+    expect(commands[0].success).toBeUndefined();
   });
 
   it('stops promptly when the signal is aborted', async () => {

--- a/src/__tests__/follow-tailer.test.ts
+++ b/src/__tests__/follow-tailer.test.ts
@@ -289,6 +289,59 @@ describe('createFollowStream', () => {
     expect(commands.map((c) => c.command)).toEqual(['echo orphan']);
   });
 
+  it('flushes orphaned pending commands during catch-up, not in the live phase', async () => {
+    // Scenario: an old session file has a tool_use with an ID but no matching
+    // tool_result (interrupted/long-running command). A newer session file has
+    // a normal command. The orphaned command should appear in chronological
+    // catch-up order — before the newer command — not deferred to the idle
+    // flush in the live loop.
+    const file1 = join(testDir, 's1.jsonl');
+    const file2 = join(testDir, 's2.jsonl');
+
+    // Old session: orphaned tool_use (has id, no tool_result)
+    await writeFile(
+      file1,
+      `${bashLine('echo orphan', { id: 'tool-orphan', timestamp: '2025-06-07T11:00:00.000Z' })}\n`
+    );
+    // Newer session: normal command (no id, yields immediately)
+    await writeFile(
+      file2,
+      `${bashLine('echo newer', { timestamp: '2025-06-07T12:00:00.000Z' })}\n`
+    );
+
+    // Set file mtimes so s1 is older than s2
+    const { utimes } = await import('node:fs/promises');
+    await utimes(
+      file1,
+      new Date('2025-06-07T11:00:00Z'),
+      new Date('2025-06-07T11:00:00Z')
+    );
+    await utimes(
+      file2,
+      new Date('2025-06-07T12:00:00Z'),
+      new Date('2025-06-07T12:00:00Z')
+    );
+
+    const gen = createFollowStream([testDir], {
+      pollMs: 20,
+      idleFlushMs: 0, // disable idle flush so we can tell where commands come from
+      signal: controller.signal,
+    });
+    const { commands, done } = background(gen);
+
+    // Wait for both commands to appear during catch-up
+    await waitFor(() => commands.length >= 2, 3000);
+    controller.abort();
+    await done;
+
+    // The orphaned command should have been flushed at the end of its file
+    // during catch-up, so it appears before the newer command.
+    expect(commands.map((c) => c.command)).toEqual([
+      'echo orphan',
+      'echo newer',
+    ]);
+  });
+
   it('stops promptly when the signal is aborted', async () => {
     await writeFile(join(testDir, 's1.jsonl'), `${bashLine('echo only')}\n`);
     const gen = createFollowStream([testDir], {

--- a/src/__tests__/follow-tailer.test.ts
+++ b/src/__tests__/follow-tailer.test.ts
@@ -1,0 +1,307 @@
+import { appendFile, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createFollowStream, FileTail } from '../follow-tailer.js';
+import type { ClaudeCommand } from '../types.js';
+
+// --- fixtures -------------------------------------------------------------
+
+let seq = 0;
+
+/** A JSONL line for a Bash tool_use. Omitting `id` makes it yield immediately. */
+function bashLine(
+  command: string,
+  opts: { id?: string; timestamp?: string } = {}
+): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          name: 'Bash',
+          ...(opts.id ? { id: opts.id } : {}),
+          input: { command },
+        },
+      ],
+    },
+    timestamp:
+      opts.timestamp ??
+      `2025-06-07T12:00:${String(seq++).padStart(2, '0')}.000Z`,
+    cwd: '/Users/test/project',
+  });
+}
+
+/** A JSONL line for a tool_result, matching a previous tool_use by id. */
+function resultLine(toolUseId: string, isError = false): string {
+  return JSON.stringify({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: toolUseId, is_error: isError },
+      ],
+    },
+    timestamp: '2025-06-07T12:30:00.000Z',
+  });
+}
+
+// --- helpers --------------------------------------------------------------
+
+async function collect(
+  gen: AsyncGenerator<ClaudeCommand> | Generator<ClaudeCommand>
+): Promise<ClaudeCommand[]> {
+  const out: ClaudeCommand[] = [];
+  for await (const cmd of gen) out.push(cmd);
+  return out;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 2000
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor: condition not met before timeout');
+    }
+    await sleep(10);
+  }
+}
+
+/** Consume a follow stream in the background into a growing array. */
+function background(gen: AsyncGenerator<ClaudeCommand>) {
+  const commands: ClaudeCommand[] = [];
+  const done = (async () => {
+    for await (const cmd of gen) commands.push(cmd);
+  })();
+  return { commands, done };
+}
+
+// --- tests ----------------------------------------------------------------
+
+describe('FileTail', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    seq = 0;
+    testDir = join(tmpdir(), `cchistory-follow-${Date.now()}-${seq}`);
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('drains data appended since the previous read', async () => {
+    const file = join(testDir, 'a.jsonl');
+    await writeFile(file, '');
+    const tail = new FileTail(file, 0);
+
+    expect(await collect(tail.drain())).toHaveLength(0);
+
+    await appendFile(file, `${bashLine('echo one')}\n`);
+    expect((await collect(tail.drain())).map((c) => c.command)).toEqual([
+      'echo one',
+    ]);
+
+    // A second drain with no new data yields nothing.
+    expect(await collect(tail.drain())).toHaveLength(0);
+
+    await appendFile(file, `${bashLine('echo two')}\n`);
+    expect((await collect(tail.drain())).map((c) => c.command)).toEqual([
+      'echo two',
+    ]);
+  });
+
+  it('buffers a partial line until the newline arrives', async () => {
+    const file = join(testDir, 'a.jsonl');
+    await writeFile(file, '');
+    const tail = new FileTail(file, 0);
+
+    const full = bashLine('echo split');
+    const half = Math.floor(full.length / 2);
+
+    await appendFile(file, full.slice(0, half));
+    expect(await collect(tail.drain())).toHaveLength(0); // incomplete line
+
+    await appendFile(file, `${full.slice(half)}\n`);
+    expect((await collect(tail.drain())).map((c) => c.command)).toEqual([
+      'echo split',
+    ]);
+  });
+
+  it('resets from the top when the file is truncated', async () => {
+    const file = join(testDir, 'a.jsonl');
+    await writeFile(file, `${bashLine('echo a')}\n${bashLine('echo b')}\n`);
+    const tail = new FileTail(file, 0);
+    expect((await collect(tail.drain())).map((c) => c.command)).toEqual([
+      'echo a',
+      'echo b',
+    ]);
+
+    // Rewrite with smaller content -> size < offset -> reset and re-read.
+    await writeFile(file, `${bashLine('echo c')}\n`);
+    expect((await collect(tail.drain())).map((c) => c.command)).toEqual([
+      'echo c',
+    ]);
+  });
+
+  it('flushPending surfaces an orphaned pending command', async () => {
+    const file = join(testDir, 'a.jsonl');
+    await writeFile(file, `${bashLine('echo waiting', { id: 'tool-1' })}\n`);
+    const tail = new FileTail(file, 0);
+
+    // Has a tool_use id but no tool_result yet -> held pending.
+    expect(await collect(tail.drain())).toHaveLength(0);
+
+    expect([...tail.flushPending()].map((c) => c.command)).toEqual([
+      'echo waiting',
+    ]);
+  });
+
+  it('emits a command once its tool_result arrives', async () => {
+    const file = join(testDir, 'a.jsonl');
+    await writeFile(file, `${bashLine('echo paired', { id: 'tool-9' })}\n`);
+    const tail = new FileTail(file, 0);
+    expect(await collect(tail.drain())).toHaveLength(0);
+
+    await appendFile(file, `${resultLine('tool-9')}\n`);
+    const cmds = await collect(tail.drain());
+    expect(cmds.map((c) => c.command)).toEqual(['echo paired']);
+    expect(cmds[0].success).toBe(true);
+  });
+});
+
+describe('createFollowStream', () => {
+  let testDir: string;
+  let controller: AbortController;
+
+  beforeEach(async () => {
+    seq = 0;
+    testDir = join(tmpdir(), `cchistory-follow-stream-${Date.now()}`);
+    await mkdir(testDir, { recursive: true });
+    controller = new AbortController();
+  });
+
+  afterEach(async () => {
+    controller.abort();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('replays history, then yields new commands as they are appended', async () => {
+    const file = join(testDir, 's1.jsonl');
+    await writeFile(file, `${bashLine('echo h1')}\n`);
+
+    const gen = createFollowStream([testDir], {
+      pollMs: 20,
+      idleFlushMs: 0,
+      signal: controller.signal,
+    });
+    const { commands, done } = background(gen);
+
+    await waitFor(() => commands.length >= 1);
+    await appendFile(file, `${bashLine('echo h2')}\n`);
+    await waitFor(() => commands.length >= 2);
+
+    controller.abort();
+    await done;
+
+    expect(commands.map((c) => c.command)).toEqual(['echo h1', 'echo h2']);
+  });
+
+  it('picks up a session file created after following starts', async () => {
+    await writeFile(join(testDir, 's1.jsonl'), `${bashLine('echo old')}\n`);
+
+    const gen = createFollowStream([testDir], {
+      pollMs: 20,
+      idleFlushMs: 0,
+      signal: controller.signal,
+    });
+    const { commands, done } = background(gen);
+
+    await waitFor(() => commands.length >= 1);
+    await writeFile(
+      join(testDir, 's2.jsonl'),
+      `${bashLine('echo brand-new')}\n`
+    );
+    await waitFor(() => commands.length >= 2);
+
+    controller.abort();
+    await done;
+
+    expect(commands.map((c) => c.command)).toContain('echo brand-new');
+  });
+
+  it('merges catch-up history from multiple projects chronologically', async () => {
+    const dirA = join(testDir, 'projA');
+    const dirB = join(testDir, 'projB');
+    await mkdir(dirA, { recursive: true });
+    await mkdir(dirB, { recursive: true });
+
+    await writeFile(
+      join(dirA, 's.jsonl'),
+      `${bashLine('echo a-first', { timestamp: '2025-06-07T12:00:00.000Z' })}\n`
+    );
+    await writeFile(
+      join(dirB, 's.jsonl'),
+      `${bashLine('echo b-second', { timestamp: '2025-06-07T12:05:00.000Z' })}\n`
+    );
+
+    const gen = createFollowStream([dirA, dirB], {
+      pollMs: 20,
+      idleFlushMs: 0,
+      signal: controller.signal,
+    });
+    const { commands, done } = background(gen);
+
+    await waitFor(() => commands.length >= 2);
+    controller.abort();
+    await done;
+
+    expect(commands.slice(0, 2).map((c) => c.command)).toEqual([
+      'echo a-first',
+      'echo b-second',
+    ]);
+  });
+
+  it('idle-flushes an unmatched pending command while following', async () => {
+    const file = join(testDir, 's1.jsonl');
+    await writeFile(file, `${bashLine('echo orphan', { id: 'tool-x' })}\n`);
+
+    const gen = createFollowStream([testDir], {
+      pollMs: 20,
+      idleFlushMs: 60,
+      signal: controller.signal,
+    });
+    const { commands, done } = background(gen);
+
+    await waitFor(() => commands.length >= 1);
+    controller.abort();
+    await done;
+
+    expect(commands.map((c) => c.command)).toEqual(['echo orphan']);
+  });
+
+  it('stops promptly when the signal is aborted', async () => {
+    await writeFile(join(testDir, 's1.jsonl'), `${bashLine('echo only')}\n`);
+    const gen = createFollowStream([testDir], {
+      pollMs: 20,
+      idleFlushMs: 0,
+      signal: controller.signal,
+    });
+    const { commands, done } = background(gen);
+
+    await waitFor(() => commands.length >= 1);
+    controller.abort();
+    await done; // resolves -> generator returned cleanly
+
+    expect(commands.map((c) => c.command)).toEqual(['echo only']);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { createFollowStream } from './follow-tailer.js';
 import { createResilientCommandStream } from './jsonl-stream-parser.js';
 import { OutputFormatter } from './output-formatter.js';
 import { ProjectDiscovery } from './project-discovery.js';
 import { StreamMerger } from './stream-merger.js';
 import type { CLIOptions, ClaudeCommand } from './types.js';
 import { version } from './version.js';
+
+// Aborted on SIGINT/SIGTERM so follow mode can stop and clean up gracefully.
+const followAbort = new AbortController();
 
 // Handle SIGPIPE gracefully (when piped to head, tail, etc.)
 process.on('SIGPIPE', () => {
@@ -43,6 +47,15 @@ export async function createCommandStream(
 
   if (options.global) {
     const projects = await discovery.getAllProjects();
+    if (options.follow) {
+      return {
+        stream: createFollowStream(
+          projects.map((p) => p.claudePath),
+          { signal: followAbort.signal }
+        ),
+        isGlobal: true,
+      };
+    }
     return {
       stream: streamMerger.mergeProjectStreams(projects),
       isGlobal: true,
@@ -64,9 +77,27 @@ export async function createCommandStream(
       { file: 'stderr' }
     );
     const projects = await discovery.getAllProjects();
+    if (options.follow) {
+      return {
+        stream: createFollowStream(
+          projects.map((p) => p.claudePath),
+          { signal: followAbort.signal }
+        ),
+        isGlobal: true,
+      };
+    }
     return {
       stream: streamMerger.mergeProjectStreams(projects),
       isGlobal: true,
+    };
+  }
+
+  if (options.follow) {
+    return {
+      stream: createFollowStream([project.claudePath], {
+        signal: followAbort.signal,
+      }),
+      isGlobal: false,
     };
   }
 
@@ -113,7 +144,9 @@ export async function processCommandStream(
     commandCount++;
   }
 
-  if (commandCount === 0) {
+  // In follow mode an empty history is normal - we wait for new commands
+  // rather than treating "nothing yet" as a not-found error.
+  if (commandCount === 0 && !options.follow) {
     process.exit(2);
   }
 }
@@ -127,11 +160,23 @@ async function main(
       return handleListProjects();
     }
 
+    if (options.follow) {
+      // Stop following on Ctrl-C / termination, letting the stream drain and
+      // the process exit cleanly (code 0) rather than aborting mid-write.
+      const stop = () => followAbort.abort();
+      process.once('SIGINT', stop);
+      process.once('SIGTERM', stop);
+    }
+
     const { stream, isGlobal } = await createCommandStream(
       projectName,
       options
     );
     await processCommandStream(stream, options, isGlobal);
+
+    if (options.follow) {
+      process.exit(0);
+    }
   } catch (error) {
     console.error(`Error: ${(error as Error).message}`, { file: 'stderr' });
     process.exit(1);
@@ -153,6 +198,10 @@ program
   .option(
     '-m, --multiline',
     'split multi-line commands onto separate lines with sub-indices (e.g. 1610.1)'
+  )
+  .option(
+    '-f, --follow',
+    'keep running and print new commands as they happen (like tail -f)'
   )
   .action(async (project: string | undefined, options: CLIOptions) => {
     await main(project, options);

--- a/src/follow-tailer.ts
+++ b/src/follow-tailer.ts
@@ -1,0 +1,280 @@
+import { open, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
+import { JSONLStreamParser } from './jsonl-stream-parser.js';
+import { StreamMerger } from './stream-merger.js';
+import type { ClaudeCommand } from './types.js';
+
+/** Maximum bytes read per file-system read while draining a growing file. */
+const READ_CHUNK_BYTES = 1024 * 1024;
+
+export interface FollowOptions {
+  /** Poll interval in milliseconds for detecting appended data. */
+  pollMs?: number;
+  /**
+   * Flush orphaned pending commands (a Bash tool_use whose tool_result never
+   * arrived) after this many milliseconds of inactivity. Set to 0 to disable.
+   */
+  idleFlushMs?: number;
+  /** Abort to stop following and let the generator return cleanly. */
+  signal?: AbortSignal;
+}
+
+const DEFAULT_POLL_MS = 300;
+const DEFAULT_IDLE_FLUSH_MS = 10_000;
+
+/**
+ * A resumable byte cursor over a single growing JSONL file.
+ *
+ * Unlike the readline-based parser (which terminates at EOF), a FileTail keeps
+ * its read offset, partial-line buffer, multi-byte decoder, and the parser's
+ * pending tool_use/tool_result state between reads. Each call to `drain()`
+ * consumes whatever has been appended since the previous call and yields the
+ * commands found, leaving the cursor ready for the next append.
+ */
+export class FileTail {
+  private offset: number;
+  private leftover = '';
+  private lineNumber = 0;
+  private readonly decoder = new StringDecoder('utf8');
+  private readonly parser = new JSONLStreamParser();
+
+  constructor(
+    public readonly filePath: string,
+    startOffset = 0
+  ) {
+    this.offset = startOffset;
+  }
+
+  /**
+   * Read and parse everything appended since the last drain, up to the file's
+   * current size. Returns once caught up; partial trailing lines (no newline
+   * yet) are buffered until a later drain completes them.
+   */
+  async *drain(signal?: AbortSignal): AsyncGenerator<ClaudeCommand> {
+    let size: number;
+    try {
+      size = (await stat(this.filePath)).size;
+    } catch {
+      // File vanished (deleted/rotated away) - nothing to read this round.
+      return;
+    }
+
+    // Truncation/rotation: the file shrank, so start over from the top.
+    if (size < this.offset) {
+      this.offset = 0;
+      this.leftover = '';
+    }
+
+    if (size <= this.offset) return;
+
+    const handle = await open(this.filePath, 'r');
+    try {
+      while (this.offset < size && !signal?.aborted) {
+        const length = Math.min(size - this.offset, READ_CHUNK_BYTES);
+        const buffer = Buffer.allocUnsafe(length);
+        const { bytesRead } = await handle.read(buffer, 0, length, this.offset);
+        if (bytesRead === 0) break;
+        this.offset += bytesRead;
+
+        const chunk =
+          this.leftover + this.decoder.write(buffer.subarray(0, bytesRead));
+        const parts = chunk.split('\n');
+        // The final element is an incomplete line (no trailing newline yet).
+        this.leftover = parts.pop() ?? '';
+
+        for (const part of parts) {
+          this.lineNumber++;
+          yield* this.parser.processLine(part, this.lineNumber, this.filePath);
+        }
+      }
+    } finally {
+      await handle.close();
+    }
+  }
+
+  /** Flush any unmatched pending commands as successful (idle/orphan flush). */
+  flushPending(): Generator<ClaudeCommand> {
+    return this.parser.flushPending();
+  }
+}
+
+/**
+ * Sleep for `ms`, resolving early if `signal` aborts.
+ */
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    function onAbort() {
+      clearTimeout(timer);
+      resolve();
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** List the `.jsonl` files in a project directory (absolute paths). */
+async function listJsonlFiles(projectPath: string): Promise<string[]> {
+  try {
+    const files = await readdir(projectPath);
+    return files
+      .filter((file) => file.endsWith('.jsonl'))
+      .map((file) => join(projectPath, file));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Drain all existing JSONL files in a project once, in modification-time order,
+ * registering a FileTail for each so the live phase can resume from exactly
+ * where catch-up stopped (no gap, no duplicates).
+ *
+ * Mirrors JSONLStreamParser.createProjectStream so the historical output of
+ * follow mode matches non-follow output.
+ */
+async function* projectCatchup(
+  projectPath: string,
+  registry: Map<string, FileTail>,
+  signal?: AbortSignal
+): AsyncGenerator<ClaudeCommand> {
+  const jsonlFiles = await listJsonlFiles(projectPath);
+
+  const fileStats = await Promise.all(
+    jsonlFiles.map(async (path) => {
+      try {
+        return { path, mtime: (await stat(path)).mtime.getTime() };
+      } catch {
+        return { path, mtime: 0 };
+      }
+    })
+  );
+  fileStats.sort((a, b) => a.mtime - b.mtime);
+
+  for (const { path } of fileStats) {
+    const tail = new FileTail(path, 0);
+    registry.set(path, tail);
+    yield* tail.drain(signal);
+  }
+}
+
+/**
+ * Register a FileTail for any `.jsonl` files that have appeared since the last
+ * scan (new Claude Code sessions started while following).
+ */
+async function discoverNewFiles(
+  projectPaths: string[],
+  registry: Map<string, FileTail>
+): Promise<void> {
+  for (const projectPath of projectPaths) {
+    for (const path of await listJsonlFiles(projectPath)) {
+      if (!registry.has(path)) {
+        registry.set(path, new FileTail(path, 0));
+      }
+    }
+  }
+}
+
+/** Drain every registered tail once, in registration order. */
+async function* drainRegistry(
+  registry: Map<string, FileTail>,
+  signal?: AbortSignal
+): AsyncGenerator<ClaudeCommand> {
+  for (const tail of registry.values()) {
+    if (signal?.aborted) return;
+    yield* tail.drain(signal);
+  }
+}
+
+/** Flush unmatched pending commands across every registered tail. */
+function* flushRegistry(
+  registry: Map<string, FileTail>
+): Generator<ClaudeCommand> {
+  for (const tail of registry.values()) {
+    yield* tail.flushPending();
+  }
+}
+
+/**
+ * After catch-up, watch the registered files (and any newly created ones) for
+ * appended commands, yielding them in arrival order until aborted.
+ */
+async function* liveLoop(
+  projectPaths: string[],
+  registry: Map<string, FileTail>,
+  options: FollowOptions
+): AsyncGenerator<ClaudeCommand> {
+  const pollMs = options.pollMs ?? DEFAULT_POLL_MS;
+  const idleFlushMs = options.idleFlushMs ?? DEFAULT_IDLE_FLUSH_MS;
+  const signal = options.signal;
+
+  let lastActivity = Date.now();
+  let flushed = false;
+
+  while (!signal?.aborted) {
+    await discoverNewFiles(projectPaths, registry);
+
+    let produced = false;
+    for await (const command of drainRegistry(registry, signal)) {
+      produced = true;
+      yield command;
+    }
+
+    if (produced) {
+      lastActivity = Date.now();
+      flushed = false;
+    } else if (
+      !flushed &&
+      idleFlushMs > 0 &&
+      Date.now() - lastActivity > idleFlushMs
+    ) {
+      // No new data for a while: surface any commands still awaiting a result.
+      yield* flushRegistry(registry);
+      flushed = true;
+    }
+
+    if (signal?.aborted) break;
+    await delay(pollMs, signal);
+  }
+}
+
+/**
+ * Stream commands like `tail -f`: first drain all existing history, then stay
+ * open and yield new commands as Claude Code appends them, until `signal`
+ * aborts.
+ *
+ * Catch-up preserves chronological ordering (single project by file mtime,
+ * multiple projects via the chronological merger). The live phase yields in
+ * arrival order across files, matching `tail -f file1 file2` semantics.
+ */
+export async function* createFollowStream(
+  projectPaths: string[],
+  options: FollowOptions = {}
+): AsyncGenerator<ClaudeCommand> {
+  const registry = new Map<string, FileTail>();
+  const signal = options.signal;
+
+  // Phase 1: catch up on existing history.
+  if (projectPaths.length === 1) {
+    yield* projectCatchup(projectPaths[0], registry, signal);
+  } else if (projectPaths.length > 1) {
+    const merger = new StreamMerger();
+    const catchupStreams = projectPaths.map((path) =>
+      projectCatchup(path, registry, signal)
+    );
+    yield* merger.chronologicalMerge(catchupStreams);
+  }
+
+  // Phase 2: follow for new appends and new sessions.
+  yield* liveLoop(projectPaths, registry, options);
+}

--- a/src/follow-tailer.ts
+++ b/src/follow-tailer.ts
@@ -93,7 +93,7 @@ export class FileTail {
     }
   }
 
-  /** Flush any unmatched pending commands as successful (idle/orphan flush). */
+  /** Flush any unmatched pending commands as unknown-outcome (idle/orphan flush). */
   flushPending(): Generator<ClaudeCommand> {
     return this.parser.flushPending();
   }
@@ -178,7 +178,7 @@ async function* projectCatchup(
     // enough to look like closed sessions. Liveness is judged by mtime age, not
     // by "is this the newest file": there may be zero live sessions (flush them
     // all, newest included) or several concurrent ones (defer them all, so no
-    // in-flight command is prematurely reported as a success).
+    // in-flight command is flushed as unknown before its real result arrives).
     if (mtime <= settledBefore) {
       yield* tail.flushPending();
     }

--- a/src/follow-tailer.ts
+++ b/src/follow-tailer.ts
@@ -142,10 +142,18 @@ async function listJsonlFiles(projectPath: string): Promise<string[]> {
  *
  * Mirrors JSONLStreamParser.createProjectStream so the historical output of
  * follow mode matches non-follow output.
+ *
+ * `settledBefore` (epoch ms) decides which files are treated as completed
+ * sessions: a file untouched at or before it is settled, so any Bash tool_use
+ * still awaiting its tool_result is flushed here, in chronological catch-up
+ * order. More recently modified files are left pending — they may belong to a
+ * live session, so the idle flush in the live loop handles them once they go
+ * quiet (a late tool_result can still match in the meantime).
  */
 async function* projectCatchup(
   projectPath: string,
   registry: Map<string, FileTail>,
+  settledBefore: number,
   signal?: AbortSignal
 ): AsyncGenerator<ClaudeCommand> {
   const jsonlFiles = await listJsonlFiles(projectPath);
@@ -161,10 +169,19 @@ async function* projectCatchup(
   );
   fileStats.sort((a, b) => a.mtime - b.mtime);
 
-  for (const { path } of fileStats) {
+  for (const { path, mtime } of fileStats) {
     const tail = new FileTail(path, 0);
     registry.set(path, tail);
     yield* tail.drain(signal);
+
+    // Flush orphaned pending commands only for files that have been quiet long
+    // enough to look like closed sessions. Liveness is judged by mtime age, not
+    // by "is this the newest file": there may be zero live sessions (flush them
+    // all, newest included) or several concurrent ones (defer them all, so no
+    // in-flight command is prematurely reported as a success).
+    if (mtime <= settledBefore) {
+      yield* tail.flushPending();
+    }
   }
 }
 
@@ -263,14 +280,20 @@ export async function* createFollowStream(
 ): AsyncGenerator<ClaudeCommand> {
   const registry = new Map<string, FileTail>();
   const signal = options.signal;
+  const idleFlushMs = options.idleFlushMs ?? DEFAULT_IDLE_FLUSH_MS;
+
+  // Files last modified at or before this instant are treated as settled
+  // (closed sessions) during catch-up; more recently touched ones are deferred
+  // to the live loop. Computed once so every project shares one reference time.
+  const settledBefore = Date.now() - idleFlushMs;
 
   // Phase 1: catch up on existing history.
   if (projectPaths.length === 1) {
-    yield* projectCatchup(projectPaths[0], registry, signal);
+    yield* projectCatchup(projectPaths[0], registry, settledBefore, signal);
   } else if (projectPaths.length > 1) {
     const merger = new StreamMerger();
     const catchupStreams = projectPaths.map((path) =>
-      projectCatchup(path, registry, signal)
+      projectCatchup(path, registry, settledBefore, signal)
     );
     yield* merger.chronologicalMerge(catchupStreams);
   }

--- a/src/jsonl-stream-parser.ts
+++ b/src/jsonl-stream-parser.ts
@@ -236,7 +236,7 @@ export class JSONLStreamParser {
   }
 
   /**
-   * Flush all currently pending (unmatched) commands as successful.
+   * Flush all currently pending (unmatched) commands as unknown-outcome.
    *
    * Mirrors the end-of-file flush for the follow tailer: when a growing file
    * goes idle with a Bash tool_use whose tool_result never arrived (e.g. a
@@ -248,11 +248,16 @@ export class JSONLStreamParser {
   }
 
   /**
-   * Flush all pending commands (assume success)
+   * Flush all pending commands with an unknown outcome.
+   *
+   * Their tool_result never arrived, so the result is genuinely unknown. We
+   * leave `success` undefined rather than assuming success: that keeps them in
+   * default output (only confirmed failures are filtered) without claiming a
+   * success we never observed.
    */
   private *flushPendingCommands(): Generator<ClaudeCommand> {
     for (const command of this.pendingCommands.values()) {
-      command.success = true; // Default to success for orphaned commands
+      // success stays undefined — outcome unknown, neither pass nor fail.
       yield command;
     }
     this.pendingCommands.clear();

--- a/src/jsonl-stream-parser.ts
+++ b/src/jsonl-stream-parser.ts
@@ -51,22 +51,35 @@ export class JSONLStreamParser {
     for await (const line of rl) {
       lineNumber++;
       entryCount++;
-      const lineStr = line.toString();
 
-      if (!lineStr.trim()) continue;
-
-      // Pre-filter: Skip lines that can't contain bash commands or user commands
-      if (!this.lineContainsCommands(lineStr)) {
-        continue;
-      }
-
-      yield* this.processEntry(lineStr, lineNumber, filePath);
+      yield* this.processLine(line.toString(), lineNumber, filePath);
 
       // Periodic cleanup of old pending commands
       if (entryCount % this.maxPendingEntries === 0) {
         yield* this.cleanupOldPendingCommands();
       }
     }
+  }
+
+  /**
+   * Process a single raw JSONL line, applying the blank/relevance pre-filter
+   * and yielding any commands it produces.
+   *
+   * Exposed so the follow tailer can feed lines incrementally as they are
+   * appended to a growing file, reusing the same pending tool_use ->
+   * tool_result matching state across reads.
+   */
+  async *processLine(
+    line: string,
+    lineNumber: number,
+    filePath: string
+  ): AsyncGenerator<ClaudeCommand> {
+    if (!line.trim()) return;
+
+    // Pre-filter: Skip lines that can't contain bash commands or user commands
+    if (!this.lineContainsCommands(line)) return;
+
+    yield* this.processEntry(line, lineNumber, filePath);
   }
 
   /**
@@ -220,6 +233,18 @@ export class JSONLStreamParser {
     }
 
     return null;
+  }
+
+  /**
+   * Flush all currently pending (unmatched) commands as successful.
+   *
+   * Mirrors the end-of-file flush for the follow tailer: when a growing file
+   * goes idle with a Bash tool_use whose tool_result never arrived (e.g. a
+   * long-running or interrupted command), surface it rather than holding it
+   * forever.
+   */
+  flushPending(): Generator<ClaudeCommand> {
+    return this.flushPendingCommands();
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,4 +55,5 @@ export interface CLIOptions {
   listProjects?: boolean;
   includeFailed?: boolean;
   multiline?: boolean;
+  follow?: boolean;
 }


### PR DESCRIPTION
## Summary

Adds `-f, --follow` so `cchistory` works like `tail -f`: it prints the existing
history and then stays open, printing new commands as Claude Code appends them —
instead of closing the stream once there are no more messages.

Following continues across newly started sessions and combines with the existing
flags and with pipes:

```bash
cchistory -f                 # Follow the current project
cchistory -f --global        # Follow every project at once
cchistory -f | grep git      # Watch for git commands as they happen
```

Press `Ctrl-C` to stop.

## How it works

Today the stream is plain EOF handling: the readline pass over each `.jsonl`
ends at end-of-file and the generator returns. Follow mode replaces every "and
then we're done" point with "and then keep watching", in two phases that share a
single byte cursor per file (so nothing appended at the boundary is missed or
duplicated):

- **Catch-up** — drains existing history exactly as before (single project by
  mtime; multiple projects via the existing chronological merger).
- **Live** — polls the tailed files plus any newly created session files,
  yielding new commands in arrival order until aborted.

New module `src/follow-tailer.ts`:
- **`FileTail`** — a resumable byte-offset cursor over one growing JSONL file.
  Keeps its read offset, a partial-line buffer, a `StringDecoder` (so multi-byte
  characters split across reads aren't corrupted), and the parser's pending
  `tool_use`→`tool_result` state between reads. Handles truncation/rotation.
- **`createFollowStream`** — orchestrates the catch-up → live phases described
  above, plus an idle-flush that surfaces a command whose `tool_result` never
  arrives (long-running or interrupted session) rather than holding it forever.

The parser gains public `processLine()` / `flushPending()` extracted from
existing private logic, so the tailer reuses the exact same parsing and matching
(no behavior change for existing callers).

CLI wiring keeps the non-follow paths untouched: `--follow` is plumbed through
`createCommandStream`, the empty-history `exit(2)` is skipped in follow mode, and
`SIGINT`/`SIGTERM` are wired to an `AbortController` for a clean exit (code 0).

## Design choices

- **Pure `stat` polling** (default 300 ms) rather than `fs.watch` — simpler,
  cross-platform, and deterministic to test. Data volume here is tiny.
- **Arrival-order** live output (matching `tail -f file1 file2`) rather than
  re-sorting the live tail by timestamp, which would require head-of-line
  blocking on the quietest file.

## Testing

- 10 new tests in `src/__tests__/follow-tailer.test.ts`: incremental drain,
  partial-line buffering, truncation reset, idle-flush, `tool_result` pairing,
  catch-up→live append, new-session pickup, multi-project chronological
  catch-up, and clean abort. **Full suite: 96 passing.**
- typecheck, biome check, and build all clean.
- Manual end-to-end: `cchistory -f` prints history then stays open and exits 0
  on Ctrl-C; `cchistory -f | head -3` prints 3 lines and exits 0 without hanging.
